### PR TITLE
setup default logging level for python services

### DIFF
--- a/model-runner/model_runner/__main__.py
+++ b/model-runner/model_runner/__main__.py
@@ -1,4 +1,5 @@
 import os
+import logging
 # pylint: disable=no-name-in-module
 from app_config import mlflow_config, service_config
 from model_runner import ModelRunner
@@ -7,6 +8,11 @@ model_handler = ModelRunner(mlflow_config, service_config)
 
 if __name__ == '__main__':
     env = os.getenv('ENVIRONMENT')
+    logging_level = os.getenv('LOG_LEVEL', logging.INFO)
+
+    log = logging.getLogger('werkzeug')
+    log.setLevel(logging_level)
+
     if env is None or env == 'production':
         model_handler.run_flask_server(port=80, host='0.0.0.0')
     if env == 'local':

--- a/prediction/prediction/__main__.py
+++ b/prediction/prediction/__main__.py
@@ -1,13 +1,18 @@
 import os
+import logging
 # pylint: disable=import-error
 from app_config import training_service_config, mlflow_models_mapping, prediction_config
 from prediction_service import PredictionService
-
 
 prediction_service = PredictionService(training_service_config, mlflow_models_mapping, prediction_config)
 
 if __name__ == '__main__':
     env = os.getenv('ENVIRONMENT')
+    logging_level = os.getenv('LOG_LEVEL', logging.INFO)
+
+    log = logging.getLogger('werkzeug')
+    log.setLevel(logging_level)
+
     if env is None or env == 'production':
         prediction_service.run_flask_server(port=80, host='0.0.0.0')
     if env == 'local':


### PR DESCRIPTION
Set default logging level for the python services (prediction and model runner).
If the env var LOG_LEVEL is not set, default level is info