### PR TITLE
Use env.log_level

### DIFF
--- a/model-runner/model_runner/app_config.py
+++ b/model-runner/model_runner/app_config.py
@@ -1,4 +1,3 @@
-import logging
 from environs import Env
 
 env = Env()
@@ -21,6 +20,6 @@ mlflow_config = {
 service_config = {
     "appinsights_key": env("APP_INSIGHTS_INSTRUMENTATION_KEY"),
     "service_name": env("SERVICE_NAME"),
-    "log_level": env.int("LOG_LEVEL", logging.INFO),
+    "log_level": env.log_level("LOG_LEVEL", "INFO"),
     "port": env.int("PORT", 80)
 }

--- a/model-runner/requirements.txt
+++ b/model-runner/requirements.txt
@@ -7,5 +7,5 @@ mlflow==0.9.0
 pandas==0.23.4
 databricks-cli
 applicationinsights==0.11.9
-environs
+environs>=5.1.0
 Werkzeug==0.11.15

--- a/prediction/prediction/app_config.py
+++ b/prediction/prediction/app_config.py
@@ -1,4 +1,3 @@
-import logging
 from environs import Env
 
 env = Env()
@@ -14,6 +13,6 @@ training_service_config = {
 mlflow_models_mapping = env.json('MLFLOW_MODELS_MAPPING')
 service_config = {
     "service_name": env("SERVICE_NAME"),
-    "log_level": env.int("LOG_LEVEL", logging.INFO),
+    "log_level": env.log_level("LOG_LEVEL", "INFO"),
     "port": env.int("PORT", 80)
 }

--- a/prediction/requirements.txt
+++ b/prediction/requirements.txt
@@ -1,5 +1,5 @@
 Flask==0.12.3
 requests
-environs
+environs>=5.1.0
 applicationinsights==0.11.9
 Werkzeug==0.11.15


### PR DESCRIPTION
environs now has first-class support for logging levels,
which may be specified as an `int` or a `str` (e.g. 'WARNING', 'INFO')